### PR TITLE
🔒 Adding an private TLS Certificate Authority generator for Mac.

### DIFF
--- a/trust_me.yml
+++ b/trust_me.yml
@@ -1,5 +1,10 @@
 #!/usr/bin/env ansible-playbook
-# Establish self-signed certificate authority for components
+#  Establish self-signed certificate authority for test components
+#
+
+#  ./trust_me.yml # to use Safari or Chrome with your own CA
+#  To create new certificate requests for local testing:
+#  make clean_certs csr
 
 - name: "trust_me.yml"
   hosts: localhost
@@ -7,6 +12,20 @@
   gather_facts: True
 
   tasks:
+    - name: 'set HOME'
+      set_fact:
+        HOME: "{{ lookup('ENV','HOME') }}"
+      tags:
+        - openssl
+        - osx
+
+    - name: 'set USER'
+      set_fact:
+        USER: "{{ lookup('ENV','USER') }}"
+      tags:
+        - openssl
+        - osx
+
     - name: 'restrict permissions on directory for our files'
       become: no
       file:
@@ -16,33 +35,128 @@
       with_items:
         - files
       tags:
-        - ssh
-        - ssl
+        - openssl
 
-    - name: 'generate RootCA key for self-signed Root certificate'
-      when: ansible_os_family == 'Darwin'
-      become: no
-      command: "openssl genrsa -out files/private/RootCA.key 1024 creates=files/private/RootCA.key"
+    - name: generate internal_ca key
+      command: openssl genrsa -out files/private/internal_ca.key 2048
+
+    - name: sign private CA key
+      command: "openssl req -x509 \
+                  -new -nodes \
+                  -key files/private/internal_ca.key \
+                  -config files/templates/openssl.cnf \
+                  -extensions ca_extensions \
+                  -days 1024 \
+                  -out files/ca-certificates/internal_ca.cer \
+                  -subj '/CN=internal_ca/O=IT/OU=Development/C=IO'"
+
+    - name: 'check the CSRs'
+      command: "openssl req -text -noout -verify -in files/certrequests/{{ item }}.csr"
+      with_inventory_hostnames: all:!localhost:!win_slave
+      no_log: no
+      changed_when: no
       tags:
-        - ssl
+        - openssl
 
-    - name: 'self-sign RootCA key, creates a root certificate'
-      when: ansible_os_family == 'Darwin'
-      become: no
-      command: "openssl req -x509 -new -nodes -key files/private/RootCA.key -days 1024 -out files/certs/RootCA.pem -subj '/C=NL/ST=DevOps/L=Appsterdam/O=bbaassssiiee/CN=bbaassssiiee Root CA' creates=files/certs/RootCA.pem"
-      register: rootca
+    - name: 'CA sign the signing requests for test'
+      command: "/bin/bash -c 'openssl x509 -req \
+                -CA files/ca-certificates/internal_ca.cer \
+                -CAkey files/private/internal_ca.key \
+                -CAcreateserial \
+                -extfile files/certrequests/{{ item }}.cnf \
+                -extensions server_cert \
+                -in files/certrequests/{{ item }}.csr \
+                -out files/ca-certificates/{{ item }}.cer \
+                -days 365'"
+      with_inventory_hostnames: all:!localhost:win_slave
       tags:
-        - ssl
+        - openssl
+        - test
 
-    - name: 'convert PEM to DER for servers'
-      when: rootca.changed
-      become: no
-      command: "openssl x509 -in files/certs/RootCA.pem -outform der -out files/certs/RootCA.cer creates=files/certs/RootCA.cer"
+    - name: 'append the root cert to the server cert'
+      shell: "cat files/ca-certificates/internal_ca.cer >> files/ca-certificates/{{ item }}.cer"
+      with_inventory_hostnames: all:!localhost:!win_slave
+      changed_when: yes
       tags:
-        - ssl
+        - openssl
 
-    - name: 'sign dev CSRs'
+    - name: "create p12 stores for testing"
+      command: "/bin/bash -c 'openssl pkcs12 -export \
+                -password pass:{{ p12_password | default('p12_password') }} \
+                -out files/private/{{ item }}.p12 \
+                -inkey files/private/{{ item }}.key \
+                -in files/ca-certificates/{{ item }}.cer'"
+      with_inventory_hostnames: all:!localhost:!win_slave
+      tags:
+        - openssl
+
+    #  The internal_ca can be stale in a new git clone
+    - name: "remove internal_ca from keychain"
+      shell: "security delete-identity -c internal_ca"
+      register: get_local_ca
+      ignore_errors: yes
+      changed_when: no
+      tags:
+        - osx
+
+    - name: "extract public key of internal_ca"
       become: no
-      local_action: shell /bin/bash --login -c 'openssl x509 -req -in {{ item }} -CA files/certs/RootCA.pem -CAkey files/private/RootCA.key -CAcreateserial -out files/certs/{{ item }}.cer -days 365'
-      with_fileglob: files/certrequests
+      command: "openssl rsa -in files/private/internal_ca.key -pubout -out files/pubkeys/internal_ca.pem"
+      tags:
+        - osx
 
+    - name: "create an encrypted store internal_ca.p12"
+      command: "/bin/bash -c 'openssl pkcs12 -export \
+                -password pass:{{ p12_password | default('p12_password') }} \
+                -out files/private/internal_ca.p12 \
+                -inkey files/private/internal_ca.key \
+                -in files/ca-certificates/internal_ca.cer'"
+      tags:
+        - osx
+
+    - name: "import internal_ca.cer in OSX login keychain with the one-time password 'p12_password'"
+      command: "open files/private/internal_ca.p12"
+      tags:
+        - osx
+
+    - name: 'ensure directory for CA config exists'
+      file:
+        path: "{{ HOME }}/Library/Application Support/Certificate Authority/internal_ca"
+        state: directory
+      tags:
+        - osx
+
+    - name: "binary hash of public key of internal_ca"
+      become: no
+      command: "openssl dgst -binary -sha256 -keyform PEM files/pubkeys/internal_ca.pem"
+      register: binary_hash
+      tags:
+        - osx
+
+    - name: 'set issuer_public_key_hash'
+      set_fact:
+        issuer_public_key_hash: "{{ binary_hash.stdout }}"
+      tags:
+        - osx
+
+    - name: 'store CA template in Library/Application Support/Certificate Authority'
+      template:
+        src: 'files/templates/certAuthorityConfig'
+        dest: "{{ HOME }}/Library/Application Support/Certificate Authority/internal_ca/internal_ca.certAuthorityConfig"
+      tags:
+        - osx
+
+    - name: "store files/ca-certificates/internal_ca.cer in Application Support/Certificate Authority"
+      copy:
+        src: "files/ca-certificates/internal_ca.cer"
+        dest: "{{ HOME }}/Library/Application Support/Certificate Authority/internal_ca/internal_ca certificates.pem"
+      tags:
+        - osx
+
+    - name: "removing plaintext keys for test"
+      file:
+        path: "files/private/{{ item }}.key"
+        state: absent
+      with_inventory_hostnames: all:!localhost:!win_slave
+      tags:
+        - openssl


### PR DESCRIPTION
trust_me.yml creates a signer CA in the Apple KeyChain.